### PR TITLE
Lazy computation for polars

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,30 +44,29 @@ cd perf_study
 
 
 ```sh
-$ pytest benchmark.py --benchmark-min-rounds=3 --benchmark-disable-gc
-
-==================================================================================================== test session starts ====================================================================================================
+$ pytest benchmark.py --benchmark-min-rounds=3 --benchmark-warmup-iterations=2 --benchmark-disable-gc
+===================================================================================================== test session starts =====================================================================================================
 platform darwin -- Python 3.11.2, pytest-7.4.0, pluggy-1.2.0
-benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=True min_rounds=3 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
-rootdir: /code/embedded-dbs/perf_study
-plugins: benchmark-4.0.0
-collected 3 items                                                                                                                                                                                                           
+benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=True min_rounds=3 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=2)
+rootdir: /code/duckdb-study/perf_study
+plugins: Faker-19.2.0, anyio-3.7.1, benchmark-4.0.0
+collected 3 items                                                                                                                                                                                                             
 
-benchmark.py ...                                                                                                                                                                                                      [100%]
+benchmark.py ...                                                                                                                                                                                                        [100%]
 
 
 ---------------------------------------------------------------------------------- benchmark: 3 tests ----------------------------------------------------------------------------------
 Name (time in s)              Min                Max               Mean            StdDev             Median               IQR            Outliers     OPS            Rounds  Iterations
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-test_benchmark_duckdb      3.6492 (1.0)       4.0477 (1.0)       3.8405 (1.0)      0.1998 (1.0)       3.8245 (1.0)      0.2989 (1.0)           1;0  0.2604 (1.0)           3           1
-test_benchmark_polars      5.4167 (1.48)      6.4685 (1.60)      5.7704 (1.50)     0.6046 (3.03)      5.4260 (1.42)     0.7888 (2.64)          1;0  0.1733 (0.67)          3           1
-test_benchmark_pandas     19.3788 (5.31)     19.8074 (4.89)     19.5716 (5.10)     0.2175 (1.09)     19.5287 (5.11)     0.3215 (1.08)          1;0  0.0511 (0.20)          3           1
+test_benchmark_duckdb      3.6226 (1.0)       3.6418 (1.0)       3.6300 (1.0)      0.0103 (1.0)       3.6257 (1.0)      0.0144 (1.0)           1;0  0.2755 (1.0)           3           1
+test_benchmark_polars      5.1474 (1.42)      6.0170 (1.65)      5.4731 (1.51)     0.4741 (45.99)     5.2548 (1.45)     0.6521 (45.25)         1;0  0.1827 (0.66)          3           1
+test_benchmark_pandas     17.6417 (4.87)     18.7966 (5.16)     18.2273 (5.02)     0.5776 (56.03)    18.2437 (5.03)     0.8662 (60.10)         1;0  0.0549 (0.20)          3           1
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Legend:
   Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
   OPS: Operations Per Second, computed as 1 / Mean
-=============================================================================================== 3 passed in 144.33s (0:02:24) ===============================================================================================
+================================================================================================ 3 passed in 138.77s (0:02:18) ================================================================================================
 ```
 
 ### Results
@@ -77,8 +76,8 @@ Average over 3 runs:
 
 | Approach | Time (sec) | Runtime increase vs. DuckDB
 |---------|----------: | --------------:
-| `duckdb` | 3.84 | 1.0
-| `polars` | 5.77 | 1.5
-| `pandas` | 19.57 | 5.1
+| `duckdb` | 3.63 | 1x
+| `polars` | 5.47 | 1.5x
+| `pandas` | 18.23 | 5x
 
-As can be seen, `duckdb` is the fastest 🔥, followed cloesly by `polars`. `pandas` is the slowest by a factor of 5x when compared to DuckDB.
+As can be seen, `duckdb` is the fastest 🔥, followed closely by `polars`. `pandas` is the slowest by a factor of 5x when compared to DuckDB.

--- a/perf_study/benchmark.py
+++ b/perf_study/benchmark.py
@@ -1,5 +1,6 @@
-import duckdb
 from pathlib import Path
+
+import duckdb
 
 from duckdb_generate import main as generate_data_duckdb
 from pandas_generate import main as generate_data_pandas
@@ -12,18 +13,18 @@ CONNECTION = duckdb.connect()
 
 
 def test_benchmark_duckdb(benchmark):
-    result = benchmark(generate_data_duckdb, CONNECTION, INPUT_FILE, NUM_PERSONS, NUM_POSITIONS, 0)
+    result = benchmark(generate_data_duckdb, CONNECTION, INPUT_FILE, NUM_PERSONS, NUM_POSITIONS)
     assert result.shape[0] == NUM_POSITIONS
     assert result.shape[1] == 5
 
 
 def test_benchmark_polars(benchmark):
-    result = benchmark(generate_data_polars, INPUT_FILE, NUM_PERSONS, NUM_POSITIONS, 0)
+    result = benchmark(generate_data_polars, INPUT_FILE, NUM_PERSONS, NUM_POSITIONS)
     assert result.shape[0] == NUM_POSITIONS
     assert result.shape[1] == 5
 
 
 def test_benchmark_pandas(benchmark):
-    result = benchmark(generate_data_pandas, INPUT_FILE, NUM_PERSONS, NUM_POSITIONS, 0)
+    result = benchmark(generate_data_pandas, INPUT_FILE, NUM_PERSONS, NUM_POSITIONS)
     assert result.shape[0] == NUM_POSITIONS
     assert result.shape[1] == 5

--- a/perf_study/pandas_generate.py
+++ b/perf_study/pandas_generate.py
@@ -6,7 +6,7 @@ import pandas as pd
 from codetiming import Timer
 
 
-def get_companies(filename: str, limit: int) -> pd.DataFrame:
+def get_companies(filename: str) -> pd.DataFrame:
     """Reads the companies data from a csv f
     ile and returns a pandas DataFrame."""
     df = pd.read_parquet(filename).rename(columns={"": "company_id"})
@@ -16,8 +16,6 @@ def get_companies(filename: str, limit: int) -> pd.DataFrame:
     df = df[df.year_founded.notnull() & df.country.notnull()]
     # Cast year_founded as int
     df.year_founded = df.year_founded.astype(int)
-    if limit > 0:
-        df = df.iloc[:limit, :]
     return df
 
 
@@ -77,9 +75,9 @@ def construct_person_company_and_location_df(
     return person_company_and_location_df
 
 
-def main(input_file: Path, num_persons: int, num_positions: int, limit: int) -> pd.DataFrame:
+def main(input_file: Path, num_persons: int, num_positions: int) -> pd.DataFrame:
     with Timer(name="read file", text="Read input file in {:.4f}s"):
-        companies = get_companies(input_file, limit)
+        companies = get_companies(input_file)
     companies_count = get_top_country_counts(companies)
     # Top 10 countries
     top_10_countries = companies_count.iloc[:10, :].index.to_list()
@@ -100,13 +98,11 @@ def main(input_file: Path, num_persons: int, num_positions: int, limit: int) -> 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--num_persons", type=int, default=int(1E6))
-    parser.add_argument("--num_positions", type=int, default=int(1E7))
+    parser.add_argument("--num_persons", type=int, default=int(1e6))
+    parser.add_argument("--num_positions", type=int, default=int(1e7))
     parser.add_argument("--input_file", type=str, default="companies_sorted.parquet")
-    parser.add_argument("--limit", type=int, default=0)
     args = parser.parse_args()
 
-    LIMIT = args.limit
     NUM_PERSONS = args.num_persons
     NUM_POSITIONS = args.num_positions
     INPUT_FILE = Path(__file__).resolve().parents[1] / "data" / args.input_file
@@ -114,6 +110,6 @@ if __name__ == "__main__":
     np.random.seed(37)
 
     with Timer(name="generation", text="Generating data completed in {:.4f}s"):
-        result = main(INPUT_FILE, NUM_PERSONS, NUM_POSITIONS, LIMIT)
+        result = main(INPUT_FILE, NUM_PERSONS, NUM_POSITIONS)
         print(f"Obtained persons, companies and locations DataFrame of shape: {result.shape}")
         print(result.head(10))

--- a/perf_study/test_generation.py
+++ b/perf_study/test_generation.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import duckdb
 
 from duckdb_generate import main as generate_data_duckdb
@@ -6,25 +7,25 @@ from pandas_generate import main as generate_data_pandas
 from polars_generate import main as generate_data_polars
 
 # 1M persons and 10M positions at companies that these 1M persons have held
-NUM_PERSONS = int(1E6)
-NUM_POSITIONS = int(1E7)
+NUM_PERSONS = int(1e6)
+NUM_POSITIONS = int(1e7)
 INPUT_FILE = Path(__file__).resolve().parents[1] / "data" / "companies_sorted.parquet"
 CONNECTION = duckdb.connect()
 
 
 def test_duckdb_generate():
-    result = generate_data_duckdb(CONNECTION, INPUT_FILE, NUM_PERSONS, NUM_POSITIONS, 0)
+    result = generate_data_duckdb(CONNECTION, INPUT_FILE, NUM_PERSONS, NUM_POSITIONS)
     assert result.shape[0] == NUM_POSITIONS
     assert result.shape[1] == 5
 
 
 def test_polars_generate():
-    result = generate_data_polars(INPUT_FILE, NUM_PERSONS, NUM_POSITIONS, 0)
+    result = generate_data_polars(INPUT_FILE, NUM_PERSONS, NUM_POSITIONS)
     assert result.shape[0] == NUM_POSITIONS
     assert result.shape[1] == 5
 
 
 def test_pandas_generate():
-    result = generate_data_pandas(INPUT_FILE, NUM_PERSONS, NUM_POSITIONS, 0)
+    result = generate_data_pandas(INPUT_FILE, NUM_PERSONS, NUM_POSITIONS)
     assert result.shape[0] == NUM_POSITIONS
     assert result.shape[1] == 5


### PR DESCRIPTION
As per #5, it makes sense to use polars' `scan_parquet` method to not materialize the entire data right at the beginning. No doubt, this helps speed up the initial stage of the dataset generation pipeline.

However, the actual task is a bit more complex than just running queries on the data -- the goal here is to construct an artificial dataset of persons, and their positions at companies, starting with the [7M+ companies dataset] from Kaggle. The parquet version of this dataset is used in combination with a random list of person IDs (with repetition), such that each person ID can be associated with multiple companies.

@ritchie46 despite my best efforts of delaying the invocation of `.collect()`, I'm unable to match the performance of DuckDB in polars. While I do not doubt that it's possible to achieve a similar level of performance with polars as I do with DuckDB for this task, I'm struggling to understand how I'd achieve this without making the code and workflow a lot less readable than either the pandas or duckdb versions. As someone who "thinks in polars", I'm sure you might find this relatively easy to speed up, so I'd love to hear your thoughts (whenever you have 10-15 mins to spare to look into this and potentially educate me). No rush at all.

Once I learn more, I'd love to write a blog post on this as it may potentially help a lot of people in the community understand these distinctions better too.